### PR TITLE
Split file open and JSON load steps into two different try blocks.

### DIFF
--- a/umake.py
+++ b/umake.py
@@ -273,10 +273,15 @@ def umakeClean(umakefileJson):
 
 # MAIN
 try:
-    with open('./umakefile', 'r') as handle:
-        umakefileJson = json.load(handle)
+    handle = open('./umakefile', 'r')
 except:
     print("./umakefile not found.")
+    exit(0)
+
+try:
+    umakefileJson = json.load(handle)
+except:
+    print("JSON load failed.")
     exit(0)
 
 try:


### PR DESCRIPTION
This is to reduce error message ambiguity.